### PR TITLE
fix(operator): comment out optional elements and re-order

### DIFF
--- a/kustomization.yml
+++ b/kustomization.yml
@@ -7,10 +7,11 @@ namespace: spinnaker
 
 resources:
   - spinnakerservice.yml               # (Mandatory). Base spinnaker manifest
-  - infrastructure/minio.yml           # (Optional, not for production use). S3 compatible data store
-  - infrastructure/mysql.yml           # (Optional, not for production use). MySQL server needed if using SQL backend in Spinnaker
-#  - infrastructure/debugging-tools.yml # (Optional). A pod with some tools for troubleshooting spinnaker (curl, kubectl, vault, etc.)
   - accounts/kubernetes/spin-sa.yml    # (Optional, needed by accounts/kubernetes/patch-kube.yml). Kubernetes service account for spinnaker to use in its own cluster
+#  - infrastructure/minio.yml           # (Optional, not for production use). S3 compatible data store
+#  - infrastructure/mysql.yml           # (Optional, not for production use). MySQL server needed if using SQL backend in Spinnaker
+#  - infrastructure/debugging-tools.yml # (Optional). A pod with some tools for troubleshooting spinnaker (curl, kubectl, vault, etc.)
+
 #bases:
 #  - infrastructure/prometheus-grafana  # (Optional). Used in conjunction with monitoring/patch-prometheus.yml for monitoring spinnaker
 

--- a/persistentStorage/patch-s3.yml
+++ b/persistentStorage/patch-s3.yml
@@ -10,9 +10,9 @@ spec:
         s3:
           bucket: spinnaker                     # The name of an S3 bucket that Spinnaker will use to save information like applications and pipelines.
           rootFolder: front50                   # The root folder in the chosen bucket to place all of Spinnaker's persistent data in.
-          region: us-west-2                     # (Optional).
-          accessKeyId: minio                    # (Optional). Your AWS Access Key ID. If not provided, Operator/Spinnaker will try to find AWS credentials as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
-          secretAccessKey: encrypted:k8s!n:spin-secrets!k:minioAccessKey # (Secret, Optional). Your AWS Secret Key.
-          pathStyleAccess: true                 # (Optional). When true, use path-style to access bucket; when false, use virtual hosted-style to access bucket.
-          endpoint: http://minio:9000           # (Optional). An alternate endpoint that your S3-compatible storage can be found at. This is intended for self-hosted storage services with S3-compatible APIs, e.g. Minio. If supplied, this storage type cannot be validated.
+#          region: us-west-2                     # (Optional).
+#          accessKeyId: minio                    # (Optional). Your AWS Access Key ID. If not provided, Operator/Spinnaker will try to find AWS credentials as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+#          secretAccessKey: encrypted:k8s!n:spin-secrets!k:minioAccessKey # (Secret, Optional). Your AWS Secret Key.
+#          pathStyleAccess: true                 # (Optional). When true, use path-style to access bucket; when false, use virtual hosted-style to access bucket.
+#          endpoint: http://minio:9000           # (Optional). An alternate endpoint that your S3-compatible storage can be found at. This is intended for self-hosted storage services with S3-compatible APIs, e.g. Minio. If supplied, this storage type cannot be validated.
 #          serverSideEncryption: AES256         # (Optional). Use Amazon Server-Side Encryption ('x-amz-server-side-encryption' header). Supports 'AES256' (for Amazon S3-managed encryption keys, equivalent to a header value of 'AES256') and 'AWSKMS' (for AWS KMS-managed encryption keys, equivalent to a header value of 'aws:kms'.


### PR DESCRIPTION
Creating a minio and mysql instance as part of the installation would not be typical at a customer site. While these may be useful for development and testing, they would not be a part of a customer production ready install. Therefore, I commented those out and then re-rodered the list so that the required items are at the top.

This assumes that a useable spinnaker install means one that has S3 and a deployment target. 