### PR TITLE
fix(k8s): fix service-account permissions to not restrict by name

### DIFF
--- a/accounts/kubernetes/spin-sa.yml
+++ b/accounts/kubernetes/spin-sa.yml
@@ -12,8 +12,6 @@ rules:
   - pods
   - ingresses/status
   - endpoints
-  resourceNames:
-  - namespaces
   verbs:
   - get
   - list


### PR DESCRIPTION
This allows the service-account to perform operations on resources that are not literally called "namespaces"