### PR TITLE
docs(readme): add operator and kustomize overview.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,22 @@
 
 This repository contains example [Kustomize](https://kustomize.io) patch files to configure and deploy Armory using the [Armory Operator](https://docs.armory.io/docs/installation/operator/), which is a Kubernetes Operator for installing Armory.
 
-The Armory Operator has a `basic` mode and a `cluster` mode. In `basic` mode, you configure Spinnaker in a single `spinnakerservice.yml` file. In `cluster` mode, though, you can configure with a single file **or** use Kustomize patch files. The advantage of using patch files is readability, consistency across environments, and maintenance manageability.  Instead of all the configuration sections in a very long `spinnakerservice.yml` file, each section is its own file, with a `kustomization.yml` file that uses the patch files to build a deployment file. See the [Managing Configuration](https://docs.armory.io/docs/installation/operator/#managing-configuration) section of the Spinnaker Operator docs for details and examples.
+The Armory Operator has a `basic` mode and a `cluster` mode.
+
+Functionality                                   | `basic` | `cluster`
+:-----------------------------------------------|:-------:|:--------:
+Can configure with single file                  |    Y    |     Y
+Can configure with kustomize patches            |    Y    |     Y
+Operator performs pre-flight checks/validations |    N    |     Y
+Requires Kubernetes 'cluster role'              |    N    |     Y
+
+Even though you can configure Armory in a single `SpinnakerService.yml` file, the advantage of using patch files is that each config section is its own file, with a `kustomization.yml` file that uses the patch files to build a deployment file. The Kustomize approach provides readability, consistency across environments, and maintenance manageability.  See the [Managing Configuration](https://docs.armory.io/docs/installation/operator/#managing-configuration) section of the Spinnaker Operator docs for details and examples.
+
+The advantage of using `deploy.sh` is one-click installation of the Armory Operator in `cluster` mode and Armory. You don't have to read several pages of documentation, configure a manifest, and execute several commands to install Armory - `deploy.sh` does it all! Additionally, this repo has many example patch files that you can easily modify to match your environment - no more creating YAML files from scratch!
+
+## Disclaimer
+
+The example configurations provided in this repository serve as a starting point for configuring Armory. You may need to modify the contents for the environment where Armory is running to work properly. These examples are not exhaustive and don't showcase all available combinations of settings. It's possible that not all configurations work with all versions of Armory.
 
 You can use these patch files, with modification, to configure a Spinnaker<sup>TM</sup> instance installed using the the open source [Spinnaker Operator](https://github.com/armory/spinnaker-operator). You need to change the `apiVersion` by removing `armory` from it. For example,
 
@@ -22,12 +37,6 @@ The `deploy.sh` script automatically does this to deploy Spinnaker when you run 
 SPIN_FLAVOR=oss ./deploy.sh
 
 ```
-
-The advantage of using `deploy.sh` is one-click installation of the Armory Operator and Armory. You don't have to read several pages of documentation, configure a manifest, and execute several commands to install Armory - `deploy.sh` does it all! Additionally, this repo has many example patch files that you can easily modify to match your environment - no more creating YAML files from scratch!
-
-## Disclaimer
-
-The example configurations provided in this repository serve as a starting point for configuring Spinnaker. You may need to modify the contents for the environment where Spinnaker is running to work properly. These examples are not exhaustive and don't showcase all available combinations of settings. It's possible that not all configurations work with all versions of Spinnaker.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains example [Kustomize](https://kustomize.io) patch files t
 
 The Armory Operator has a `basic` mode and a `cluster` mode. In `basic` mode, you configure Spinnaker in a single `spinnakerservice.yml` file. In `cluster` mode, though, you can configure with a single file **or** use Kustomize patch files. The advantage of using patch files is readability, consistency across environments, and maintenance manageability.  Instead of all the configuration sections in a very long `spinnakerservice.yml` file, each section is its own file, with a `kustomization.yml` file that uses the patch files to build a deployment file. See the [Managing Configuration](https://docs.armory.io/docs/installation/operator/#managing-configuration) section of the Spinnaker Operator docs for details and examples.
 
-You can use these patch files, with modification, to configure a Spinnaker instance installed using the the open source [Spinnaker Operator](https://github.com/armory/spinnaker-operator). You need to change the `apiVersion` by removing `armory` from it. For example,
+You can use these patch files, with modification, to configure a Spinnaker<sup>TM</sup> instance installed using the the open source [Spinnaker Operator](https://github.com/armory/spinnaker-operator). You need to change the `apiVersion` by removing `armory` from it. For example,
 
 ```
 apiVersion: spinnaker.armory.io/v1alpha2

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ The `deploy.sh` script automatically does this to deploy Spinnaker when you run 
 
 ```bash
 SPIN_FLAVOR=oss ./deploy.sh
+
 ```
+
+The advantage of using `deploy.sh` is one-click installation of the Armory Operator and Armory. You don't have to read several pages of documentation, configure a manifest, and execute several commands to install Armory - `deploy.sh` does it all! Additionally, this repo has many example patch files that you can easily modify to match your environment - no more creating YAML files from scratch!
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,48 @@
-# spinnaker-kustomize-patches
+# Kustomize Patches for Armory
 
-This repository contains example [kustomize](https://kustomize.io) patch files to configure and deploy Spinnaker using the Spinnaker Operator.
+This repository contains example [Kustomize](https://kustomize.io) patch files to configure and deploy Armory using the [Armory Operator](https://docs.armory.io/docs/installation/operator/), which is a Kubernetes Operator for installing Armory.
 
-### Disclaimer
+The Armory Operator has a `basic` mode and a `cluster` mode. In `basic` mode, you configure Spinnaker in a single `spinnakerservice.yml` file. In `cluster` mode, though, you can configure with a single file **or** use Kustomize patch files. The advantage of using patch files is readability, consistency across environments, and maintenance manageability.  Instead of all the configuration sections in a very long `spinnakerservice.yml` file, each section is its own file, with a `kustomization.yml` file that uses the patch files to build a deployment file. See the [Managing Configuration](https://docs.armory.io/docs/installation/operator/#managing-configuration) section of the Spinnaker Operator docs for details and examples.
 
-The example configurations provided in this repository serve as a starting point for configuring Spinnaker, usually they may need to be adjusted to the environment where Spinnaker is running to work properly. These examples are not exhaustive and don't showcase all available combinations of settings. It's possible that not all configurations work with all versions of Spinnaker. 
+You can use these patch files, with modification, to configure a Spinnaker instance installed using the the open source [Spinnaker Operator](https://github.com/armory/spinnaker-operator). You need to change the `apiVersion` by removing `armory` from it. For example,
 
-### Prerequisites
+```
+apiVersion: spinnaker.armory.io/v1alpha2
+```
 
-* You need to have a working Kubernetes cluster, and be able to execute `kubectl` commands against that cluster, with permissions to list and create namespaces.
+changes to:
+
+```
+apiVersion: spinnaker.io/v1alpha2
+```
+
+The `deploy.sh` script automatically does this to deploy Spinnaker when you run it with the `SPIN_FLAVOR` environment variable:
+
+```bash
+SPIN_FLAVOR=oss ./deploy.sh
+```
+
+## Disclaimer
+
+The example configurations provided in this repository serve as a starting point for configuring Spinnaker. You may need to modify the contents for the environment where Spinnaker is running to work properly. These examples are not exhaustive and don't showcase all available combinations of settings. It's possible that not all configurations work with all versions of Spinnaker.
+
+## Prerequisites
+
+You need to have a working Kubernetes cluster and be able to execute `kubectl` commands against that cluster, with permissions to list and create namespaces.
 
 ### Quick start
 
-Run `./deploy.sh`. 
+Clone this repository and run `./deploy.sh`.
 
-It will deploy Spinnaker Operator to `spinnaker-operator` namespace, and a base Spinnaker instance to `spinnaker` namespace with some default integrations.
+This will deploy the Armory Operator to the `spinnaker-operator` namespace, and a base Armory instance to the `spinnaker` namespace with some default integrations.
 
-### General usage
+## General usage
 
 1. Make a link from `kustomization.yml` to one of the example kustomization files in `recipes` folder depending on your use case.
 1. Modify `kustomization.yml` by adding or removing patches depending on what you want to be included in spinnaker. [Kustomization Reference Documentation describes the syntax of this file](https://kubectl.docs.kubernetes.io/pages/reference/kustomize.html).
 1. Change any of the kustomize patch files to match your desired configuration. For example changing github username, aws account id, etc.
 1. Store secret literals in `secrets/secrets.env` and secret files in `secrets/files` if you want to store spinnaker secrets in Kubernetes. They are ignored by source control.
-1. Run `./deploy.sh` to deploy spinnaker. 
+1. Run `./deploy.sh` to deploy spinnaker.
 
 * Namespace for the Spinnaker Operator is configured in `operator/kustomization.yml`.
 * Namespace for Spinnaker and all its infrastructure is configured in `kustomization.yml`.
@@ -31,17 +51,4 @@ It will deploy Spinnaker Operator to `spinnaker-operator` namespace, and a base 
 
 For adding remote Kubernetes clusters to Spinnaker, the helper script `secrets/create-kubeconfig.sh` can be used to create a Kubernetes service account (with cluster admin role) and its corresponding `kubeconfig` file for spinnaker to use.
 
-### OSS Spinnaker or Armory Spinnaker
 
-All kustomize patch files in this repository are for Armory Spinnaker distribution. For using with OSS Spinnaker you need to change their `apiVersion` by removing `armory` from it. For example, 
-```
-apiVersion: spinnaker.armory.io/v1alpha2
-```
-changes to: 
-```
-apiVersion: spinnaker.io/v1alpha2
-```
-The script `deploy.sh` automatically does this to deploy OSS Spinnaker when run with the `SPIN_FLAVOR` environment variable:
-```bash
-SPIN_FLAVOR=oss ./deploy.sh
-```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains example [Kustomize](https://kustomize.io) patch files to configure and deploy Armory using the [Armory Operator](https://docs.armory.io/docs/installation/operator/), which is a Kubernetes Operator for installing Armory.
 
-The Armory Operator has a `basic` mode and a `cluster` mode.
+The Armory Operator has `basic` and a `cluster` modes.
 
 Functionality                                   | `basic` | `cluster`
 :-----------------------------------------------|:-------:|:--------:
@@ -13,7 +13,7 @@ Requires Kubernetes 'cluster role'              |    N    |     Y
 
 Even though you can configure Armory in a single `SpinnakerService.yml` file, the advantage of using patch files is that each config section is its own file, with a `kustomization.yml` file that uses the patch files to build a deployment file. The Kustomize approach provides readability, consistency across environments, and maintenance manageability.  See the [Managing Configuration](https://docs.armory.io/docs/installation/operator/#managing-configuration) section of the Spinnaker Operator docs for details and examples.
 
-The advantage of using `deploy.sh` is one-click installation of the Armory Operator in `cluster` mode and Armory. You don't have to read several pages of documentation, configure a manifest, and execute several commands to install Armory - `deploy.sh` does it all! Additionally, this repo has many example patch files that you can easily modify to match your environment - no more creating YAML files from scratch!
+This repo provides one-click installation of the Armory Operator (`cluster` mode) and Armory via the `deploy.sh` script. You don't have to read the Armory Operator documentation before you start, configure a manifest, or execute several commands to install Armory - `deploy.sh` does it all! Additionally, this repo has many example patch files that you can easily modify to match your environment - no more creating YAML files from scratch!
 
 ## Disclaimer
 
@@ -63,4 +63,9 @@ This will deploy the Armory Operator to the `spinnaker-operator` namespace, and 
 
 For adding remote Kubernetes clusters to Spinnaker, the helper script `secrets/create-kubeconfig.sh` can be used to create a Kubernetes service account (with cluster admin role) and its corresponding `kubeconfig` file for spinnaker to use.
 
+## Resources
+
+* [Armory Operator](https://docs.armory.io/docs/installation/operator/)
+* [Armory Operator Configuration](https://docs.armory.io/docs/installation/operator-reference/operator-config/)
+* [Kustomize](https://kustomize.io)
 

--- a/plugins/patch-plugin-wait.yml
+++ b/plugins/patch-plugin-wait.yml
@@ -7,21 +7,33 @@ metadata:
   name: spinnaker
 spec:
   spinnakerConfig:
-    config:
-      spinnaker:
-        extensibility:
-          plugins:
-            Armory.RandomWaitPlugin:
-              id: Armory.RandomWaitPlugin
+    # spec.spinnakerConfig.profiles - This section contains the YAML of each service's profile
+    profiles:
+      gate:
+        spinnaker:
+          extensibility:
+            deck-proxy: # you need this for plugins with a Deck component
               enabled: true
-              version: 1.1.11
-              extensions:
-                armory.randomWaitStage:
-                  id: armory.randomWaitStage
+              plugins:
+                Armory.RandomWaitPlugin:
                   enabled: true
-                  config:
-                    defaultMaxWaitTime: 3
-          repositories:
-            github-repository:
-              id: github-repository
-              url: https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/plugins.json
+                  version: 1.1.14
+            repositories:
+              examplePluginsRepo:
+                url: https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/plugins.json
+      orca:
+        spinnaker:
+          extensibility:
+    		   plugins:
+    		     Armory.RandomWaitPlugin:
+    			    enabled: true
+    			    version: 1.1.14
+    			    extensions:
+    				   id: armory.randomWaitStage
+    				   enabled: true
+    				   config:
+    				     defaultMaxWaitTime: 15
+    		   repositories:
+    		     examplePluginsRepo:
+    			    id: examplePluginsRepo
+    			    url: https://raw.githubusercontent.com/spinnaker-plugin-examples/examplePluginRepository/master/plugins.json


### PR DESCRIPTION
Jira https://armory.atlassian.net/browse/PUX-179


```
As a potential user of Spinnaker, I would like to know how the spinnaker-kustomize-patches repo helps me configure Spinnaker faster, so that I can adopt Spinnaker for my organization.

The solution is likely linking to our existing documentation, but it couldn't hurt to add a little more exposition in the repo.

Definition of Done:

    The spinnaker-kustomize-patches repo answers the following questions
        What is the Spinnaker Operator?
        If I'm not familiar with Kustomize or Operator, how does this repo accelerate my adoption of Spinnaker?
```
