### PR TITLE
update(ingress): add config profiles and service-settings

### DIFF
--- a/expose/patch-ingress.yml
+++ b/expose/patch-ingress.yml
@@ -11,3 +11,17 @@ metadata:
 spec:
   expose:
     type: ingress  # Spinnaker is exposed using ingress. Available options: service, ingress
+  config:
+    security:
+      apiSecurity:
+        overrideBaseUrl: https://spinnaker.mycompany.com/api  # Public API (Gate) url. Using the same hostname for deck and gate only works when exposing spinnaker with ingress.
+      uiSecurity:
+        overrideBaseUrl: https://spinnaker.mycompany.com     # Public UI (Deck) url.
+  profiles:
+    gate:
+      server:
+        servlet:
+          context-path: /api
+  service-settings:
+    gate:
+      healthEndpoint: /api/health


### PR DESCRIPTION
@german-muzquiz I think we should add the config / profiles and service-settings to this patch file (patch-ingress.yml) 

or actually - now that I'm typing it out - maybe to the `patch-urls.yml`  

Either way - if we're going to change the urls to use an api endpoint, especially for gate, we need to also update the profiles / service-settings for health endpoint and context-path... 


3rd option is to have an entirely separate patch that does what i'm trying to do.  what do you think?
