### PR TITLE
feature(kustomize): fiat and authz with external

### DIFF
--- a/armory/patch-dinghy.yml
+++ b/armory/patch-dinghy.yml
@@ -15,6 +15,7 @@ spec:
           enabled: true
           templateOrg: my-org                                      # SCM organization or namespace where application and template repositories are located
           templateRepo: dinghy-templates                           # SCM repository where module templates are located
+#           fiatUser: dinghy-sa                                     # Service account for dinghy to use, required if fiat is enabled
           # --- github settings
           githubToken: encrypted:k8s!n:spin-secrets!k:github-token # (Secret). GitHub token
 #          githubEndpoint: https://api.github.com                   # (Default: https://api.github.com) Github API endpoint. Useful if you’re using Github Enterprise

--- a/security/patch-external-authz.yml
+++ b/security/patch-external-authz.yml
@@ -1,0 +1,19 @@
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    config:
+      features:
+        fiat: true
+      security:
+        authz:
+          enabled: true
+          groupMembership:
+            service: EXTERNAL
+    profiles:
+      fiat:
+        admin:
+          roles:
+            - spin-admin      #Assign external group spin-admin to the Spinnaker administrator role


### PR DESCRIPTION
provide patch file for turning on fiat with authz against an external provider, and put placeholder in for dinghy SA to use when fiat is enabled. 