### PR TITLE
fix(gate): Change URL to something that works

### DIFF
--- a/expose/ingress-nginx.yml
+++ b/expose/ingress-nginx.yml
@@ -32,4 +32,4 @@ spec:
           - backend:
               serviceName: spin-gate
               servicePort: 8084
-            path: /api
+            path: /api/v1

--- a/expose/patch-urls.yml
+++ b/expose/patch-urls.yml
@@ -10,6 +10,6 @@ spec:
     config:
       security:
         apiSecurity:
-          overrideBaseUrl: https://spinnaker.mycompany.com/api  # Public API (Gate) url. Using the same hostname for deck and gate only works when exposing spinnaker with ingress.
+          overrideBaseUrl: https://spinnaker.mycompany.com/api/v1  # Public API (Gate) url. Using the same hostname for deck and gate only works when exposing spinnaker with ingress.
         uiSecurity:
           overrideBaseUrl: https://spinnaker.mycompany.com      # Public UI (Deck) url.


### PR DESCRIPTION
Change Gate URL to something that works (api/v1) when Gate is
on the same host but different path then Deck.