### PR TITLE
fix(secret_script): fix create-secrets to be more robust

### DIFF
--- a/secrets/create-secrets.sh
+++ b/secrets/create-secrets.sh
@@ -38,11 +38,11 @@ SEC_FILE=$CWD/secrets.env
 [[ ! -f $SEC_FILE  ]] && echo "WARNING: Missing file $SEC_FILE, loading sample secrets from $CWD/secrets-example.env instead" && SEC_FILE=$CWD/secrets-example.env
 while IFS='=' read -r literalsLine; 
 do
-    echo "Including secret literal \"$(echo $literalsLine)\""
+    #echo "Including secret literal \"$(echo $literalsLine)\""
     literalsKey="${literalsLine%%=*}"
-    echo "key is ${literalsKey}"
+    #echo "key is ${literalsKey}"
     literalsValue="${literalsLine#*=}"
-    echo "val is ${literalsValue}"
+    #echo "val is ${literalsValue}"
     if [[ $literalsValue =~ $quoteRequiredRegex ]]; then
         echo "space(s) detected inside value for ${literalsKey}, so wrapping with double quotes"
         LITERALS+="--from-literal=${literalsKey}=\"${literalsValue}\" "

--- a/secrets/create-secrets.sh
+++ b/secrets/create-secrets.sh
@@ -33,14 +33,23 @@ then
   kubectl -n "$NAMESPACE" delete secret spin-secrets
 fi
 
+quoteRequiredRegex="[[:space:]]+"
 SEC_FILE=$CWD/secrets.env
 [[ ! -f $SEC_FILE  ]] && echo "WARNING: Missing file $SEC_FILE, loading sample secrets from $CWD/secrets-example.env instead" && SEC_FILE=$CWD/secrets-example.env
-while IFS= read -r l
+while IFS='=' read -r literalsLine; 
 do
-  echo "Including secret literal \"$(echo $l | sed 's|=.*||')\""
-  LITERALS+="--from-literal=$l "
-done < <(grep -v -e '^#' -e '^$' < "$SEC_FILE")
-LITERALS=${LITERALS::${#LITERALS}-1}
+    echo "Including secret literal \"$(echo $literalsLine)\""
+    literalsKey="${literalsLine%%=*}"
+    echo "key is ${literalsKey}"
+    literalsValue="${literalsLine#*=}"
+    echo "val is ${literalsValue}"
+    if [[ $literalsValue =~ $quoteRequiredRegex ]]; then
+        echo "space(s) detected inside value for ${literalsKey}, so wrapping with double quotes"
+        LITERALS+="--from-literal=${literalsKey}=\"${literalsValue}\" "
+    else
+        LITERALS+="--from-literal=${literalsKey}=${literalsValue} "
+    fi
+done <"$SEC_FILE"
 
 if [[ -d "$CWD"/files && -n "$(ls -A "$CWD"/files)" ]]; then
   for f in "$CWD"/files/*


### PR DESCRIPTION
Now should support spaces inside the secret value (property value)
Now should support any standard string after the initial `=` inside the `secrets.env`
The `create-secrets.sh` is so rarely run that I figured it was ok to have a bit more debug information in there.