### PR TITLE
feat(sidecars): sidecar examples

### DIFF
--- a/recipes/kustomization-all.yml
+++ b/recipes/kustomization-all.yml
@@ -82,6 +82,7 @@ patchesStrategicMerge:
 #  - spinnaker_deployment/patch-sizing.yml
 #  - spinnaker_deployment/patch-labels-annotations.yml
 #  - spinnaker_deployment/patch-debug-jvm.yml
+#  - spinnaker_deployment/patch-cloudsql-sidecars.yml    ## (Optional) Google Cloud Proxy Sidecars for CloudSQL
 
   # Customization to core configuration
   - core_config/patch-timezone.yml                      ## (Optional) adjust the display timezone visible to the user within deck

--- a/spinnaker_deployment/patch-cloudsql-sidecars.yml
+++ b/spinnaker_deployment/patch-cloudsql-sidecars.yml
@@ -1,0 +1,54 @@
+#-----------------------------------------------------------------------------------------------------------------
+# Example configuration for adding sidecars to spinnaker pods (In this case, to enable Google CloudSQL Proxy)
+#-----------------------------------------------------------------------------------------------------------------
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    config:
+      deploymentEnvironment:
+        sidecars:
+          spin-orca:
+          - name: cloudsql-proxy
+            dockerImage: gcr.io/cloudsql-docker/gce-proxy:1.13
+            port: 3306
+            command:
+            - '''/cloud_sql_proxy'''
+            - '''--dir=/cloudsql'''
+            - '''-instances=my-gcp-project:us-east1:my-spinnaker-cloudsql-instance=tcp:3306'''
+            - '''-credential_file=/secrets/cloudsql/spinnaker-cloudsql-account.json'''                # change to file name that has the google service account with the 'Cloud SQL Client' permissions
+            secretVolumeMounts:
+            - secretName: spin-secrets
+              mountPath: /secrets/cloudsql
+            mountPath: /cloudsql
+          spin-clouddriver:
+          - name: cloudsql-proxy
+            dockerImage: gcr.io/cloudsql-docker/gce-proxy:1.13
+            port: 3306
+            command:
+            - '''/cloud_sql_proxy'''
+            - '''--dir=/cloudsql'''
+            - '''-instances=my-gcp-project:us-east1:my-spinnaker-cloudsql-instance=tcp:3306'''
+            - '''-credential_file=/secrets/cloudsql/spinnaker-cloudsql-account.json'''                # change to file name that has the google service account with the 'Cloud SQL Client' permissions
+            secretVolumeMounts:
+            - secretName: spin-secrets
+              mountPath: /secrets/cloudsql
+            mountPath: /cloudsql
+          - name: token-refresh
+            dockerImage: armory/gcloud-auth-helper:stable                                             # Sidecar to help with gcloud authentication token timeouts https://github.com/armory-io/gcloud-auth-helper
+            mountPath: /tmp/gcloud
+          spin-front50:
+          - name: cloudsql-proxy
+            dockerImage: gcr.io/cloudsql-docker/gce-proxy:1.13
+            port: 3306
+            command:
+            - '''/cloud_sql_proxy'''
+            - '''--dir=/cloudsql'''
+            - '''-instances=my-gcp-project:us-east1:my-spinnaker-cloudsql-instance=tcp:3306'''
+            - '''-credential_file=/secrets/cloudsql/spinnaker-cloudsql-account.json'''                # change to file name that has the google service account with the 'Cloud SQL Client' permissions
+            secretVolumeMounts:
+            - secretName: spin-secrets
+              mountPath: /secrets/cloudsql
+            mountPath: /cloudsql


### PR DESCRIPTION
The following sidecar examples:
- Using Google Cloud SQL for Spinnaker database support outside of Google Cloud if desired
- Using a token authentication sidecar to utilize gcloud for authentication to GKE clusters without triggering rate limits