### PR TITLE
feat(sql): Prevent collation errors in queries

### DIFF
--- a/persistence/patch-sql-clouddriver.yml
+++ b/persistence/patch-sql-clouddriver.yml
@@ -31,7 +31,7 @@ spec:
               # for more detail and to view defaults, see:
               # https://github.com/spinnaker/kork/blob/master/kork-sql/src/main/kotlin/com/netflix/spinnaker/kork/sql/config/ConnectionPoolProperties.kt
               default: true
-              jdbcUrl: jdbc:mysql://mysql:3306/clouddriver?useSSL=false&useUnicode=true&characterEncoding=utf8 # useUnicode and utf8 makes sure the database can store an emoji if one is ever added to the database
+              jdbcUrl: jdbc:mysql://mysql:3306/clouddriver?useSSL=false&useUnicode=true&characterEncoding=utf8&connectionCollation=utf8mb4_unicode_ci # useUnicode and utf8 makes sure the database can store an emoji if one is ever added to the database
               user: clouddriver_service
               password: encrypted:k8s!n:spin-secrets!k:mysqlCdPassword  # (Secret). Depending on db auth and how spinnaker secrets are managed
             # The following tasks connection pool is optional. At Netflix, clouddriver
@@ -41,11 +41,11 @@ spec:
             tasks:
               user: clouddriver_service
               password: encrypted:k8s!n:spin-secrets!k:mysqlCdPassword  # (Secret). Depending on db auth and how spinnaker secrets are managed
-              jdbcUrl: jdbc:mysql://mysql:3306/clouddriver?useSSL=false&useUnicode=true&characterEncoding=utf8 # useUnicode and utf8 makes sure the database can store an emoji if one is ever added to the database
+              jdbcUrl: jdbc:mysql://mysql:3306/clouddriver?useSSL=false&useUnicode=true&characterEncoding=utf8&connectionCollation=utf8mb4_unicode_ci # useUnicode and utf8 makes sure the database can store an emoji if one is ever added to the database
           migration:
             user: clouddriver_migrate
             password: encrypted:k8s!n:spin-secrets!k:mysqlCdMigratePassword  # (Secret). Depending on db auth and how spinnaker secrets are managed
-            jdbcUrl: jdbc:mysql://mysql:3306/clouddriver?useSSL=false&useUnicode=true&characterEncoding=utf8 # useUnicode and utf8 makes sure the database can store an emoji if one is ever added to the database
+            jdbcUrl: jdbc:mysql://mysql:3306/clouddriver?useSSL=false&useUnicode=true&characterEncoding=utf8&connectionCollation=utf8mb4_unicode_ci # useUnicode and utf8 makes sure the database can store an emoji if one is ever added to the database
         
         dualTaskRepository: # Maintaining Task Repository Availability While Migrating from Redis to SQL in production https://spinnaker.io/setup/productionize/persistence/clouddriver-sql/#maintaining-task-repository-availability-while-migrating-from-redis-to-sql
           enabled: false


### PR DESCRIPTION
Setting encoding=utf8  updates the tables but may cause an error similar to the following

`jOOQ; uncategorized SQLException for SQL [..] for operation '='; nested exception is java.sql.SQLException: Illegal mix of collations (utf8mb4_general_ci,IMPLICIT) and (utf8mb4_unicode_ci,IMPLICIT)`

Since the collation in tables is now utf8mb4_general_ci, but the collation in string expression is utf8mb4_general_ci.
This affects kubesvc mostly