### PR TITLE
feat(rosco): added rosco environment variables

### DIFF
--- a/accounts/aws/patch-aws.yml
+++ b/accounts/aws/patch-aws.yml
@@ -56,3 +56,6 @@ spec:
 #      clouddriver:
 #        env:
 #          EC2_REGION: us-west-2
+#      rosco:
+#        env:
+#          AWS_REGION: us-west-2


### PR DESCRIPTION
this error started showing up 2.23.1
```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'armoryAWSBakeHandler' defined in URL [jar:file:/opt/rosco/lib/rosco-package-2.23.5.jar!/com/netflix/spinnaker/rosco/providers/aws/ArmoryAWSBakeHandler.class]: Bean instantiation via constructor failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [com.netflix.spinnaker.rosco.providers.aws.ArmoryAWSBakeHandler]: Constructor threw exception; nested exception is software.amazon.awssdk.core.exception.SdkClientException: Unable to load region from any of the providers in the chain software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain@f5475d7: [software.amazon.awssdk.regions.providers.SystemSettingsRegionProvider@21845b36: Unable to load region from system settings. Region must be specified either via environment variable (AWS_REGION) or  system property (aws.region)., software.amazon.awssdk.regions.providers.AwsProfileRegionProvider@74cf108b: No region provided in profile: default, software.amazon.awssdk.regions.providers.InstanceProfileRegionProvider@5b83545d: Unable to contact EC2 metadata service.]
```