### PR TITLE
fix(gate): proposal to use different endpoint by default.

### DIFF
--- a/expose/patch-urls.yml
+++ b/expose/patch-urls.yml
@@ -10,6 +10,6 @@ spec:
     config:
       security:
         apiSecurity:
-          overrideBaseUrl: https://spinnaker.mycompany.com/api/v1  # Public API (Gate) url. Using the same hostname for deck and gate only works when exposing spinnaker with ingress.
+          overrideBaseUrl: https://spinnaker-gate.mycompany.com  # Public API (Gate) url. Using the same hostname for deck and gate only works when exposing spinnaker with ingress.
         uiSecurity:
           overrideBaseUrl: https://spinnaker.mycompany.com      # Public UI (Deck) url.


### PR DESCRIPTION
Its actually confusing for a new user if we use the api/v1 endpoint in this file - unless we also include gate service-settings to move the endpoint to /api/v1