### PR TITLE
fix(accounts/kubernetes): Updating the default credentials for the spin-sa user in kubernetes

### DIFF
--- a/accounts/kubernetes/spin-sa.yml
+++ b/accounts/kubernetes/spin-sa.yml
@@ -17,6 +17,9 @@ rules:
   - list
   - watch
   - create
+  - update
+  - patch
+  - delete
 - apiGroups:
   - ""
   resources:
@@ -35,6 +38,7 @@ rules:
   - update
   - watch
   - patch
+  - delete
 - apiGroups:
   - batch
   resources:
@@ -52,6 +56,7 @@ rules:
   resources:
   - deployments
   - deployments/finalizers
+  - deployments/scale
   - daemonsets
   - replicasets
   - statefulsets
@@ -62,6 +67,7 @@ rules:
   - update
   - watch
   - patch
+  - delete
 - apiGroups:
   - monitoring.coreos.com
   resources:


### PR DESCRIPTION
Updated the default credentials for the spin-sa user when deployed in kubernetes. this is attempting to fix an issue when run in Amazon EKS where certain features in the spinnaker UI give permissions errors. Specifically: with the existing permissions I could not delete infrastructure on the infrastructure tab, and I could not use the 'scale (manifest)' step to scale my deployment. following these permissions changes, those features worked without issue.