### PR TITLE
fix(traefik): Fix Traefik redirect to https

### DIFF
--- a/expose/ingress-traefik.yml
+++ b/expose/ingress-traefik.yml
@@ -11,6 +11,7 @@ metadata:
     cluster: spin-ingress
   annotations:
     kubernetes.io/ingress.class: traefik
+    traefik.ingress.kubernetes.io/redirect-entry-point: https
 spec:
   rules:
   - host: spinnaker.mycompany.com           # Public facing spinnaker domain


### PR DESCRIPTION
If you don't put https in the URL the basic auth login will
result in 400 error because it's trying to go to the http URL.
This forces a redirect to the https URL.