### PR TITLE
doc(opa): Update opa manifest comments.

### DIFF
--- a/infrastructure/opa.yml
+++ b/infrastructure/opa.yml
@@ -3,6 +3,9 @@
 #
 # If namespace is changed in root kustomization.yml or this manifest is deployed outside of it,
 # please update the namespace in all RoleBinding and ClusterRoleBinding definitions under "subjects.name".
+#
+# Note that the commented namespace definition for "opa" below will not apply if this patch is invoked by
+# a kustomization.yml file with a namespace defined.
 #-----------------------------------------------------------------------------------------------------------------
 #---
 #apiVersion: v1

--- a/infrastructure/opa.yml
+++ b/infrastructure/opa.yml
@@ -1,12 +1,13 @@
-#-----------------------------------------------------------------------------------------------------------------
+#-------------------------------------------------------------------------------------
 # NOTE: "namespace" field in all objects is overridden by root kustomization.yml file.
 #
-# If namespace is changed in root kustomization.yml or this manifest is deployed outside of it,
-# please update the namespace in all RoleBinding and ClusterRoleBinding definitions under "subjects.name".
+# If namespace is changed in root kustomization.yml or this manifest is deployed
+# outside of it, please update the namespace in all RoleBinding and ClusterRoleBinding
+# definitions under "subjects.name".
 #
-# Note that the commented namespace definition for "opa" below will not apply if this patch is invoked by
-# a kustomization.yml file with a namespace defined.
-#-----------------------------------------------------------------------------------------------------------------
+# Note that the commented namespace definition for "opa" below will not apply if this
+# patch is invoked by a kustomization.yml file with a namespace defined.
+#-------------------------------------------------------------------------------------
 #---
 #apiVersion: v1
 #kind: Namespace

--- a/infrastructure/opa.yml
+++ b/infrastructure/opa.yml
@@ -2,7 +2,7 @@
 # NOTE: "namespace" field in all objects is overridden by root kustomization.yml file.
 #
 # If namespace is changed in root kustomization.yml or this manifest is deployed outside of it,
-# please update the namespace in all RolBinding and ClusterRoleBinding definitions under "subjects.name".
+# please update the namespace in all RoleBinding and ClusterRoleBinding definitions under "subjects.name".
 #-----------------------------------------------------------------------------------------------------------------
 #---
 #apiVersion: v1


### PR DESCRIPTION
Clarifies that the namespace definition will not be used when namespace is defined in `kustomization.yml`. Also adjusts the comment block width.