### PR TITLE
feat(armory.io): add webhooks to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ secrets.env
 !halyard-local.yml
 operator/deploy
 deploy_log.txt
+webhooks/*


### PR DESCRIPTION
feat(armory.io): add webhooks to gitignore

Added ignore for webhooks directory in case it is added and base64 encoded credentials are added.