### PR TITLE
fix(minio): Use a fixed tag instead of latest

### DIFF
--- a/infrastructure/minio.yml
+++ b/infrastructure/minio.yml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: minio
-          image: minio/minio
+          image: minio/minio:RELEASE.2021-08-20T18-32-01Z
           command:
           - /bin/sh
           - -c


### PR DESCRIPTION
Fixes a problem with current latest image of "minio not found" error.