### PR TITLE
Add minio fix to minnaker branch

### DIFF
--- a/infrastructure/minio.yml
+++ b/infrastructure/minio.yml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
         - name: minio
-          image: minio/minio
+          image: minio/minio:RELEASE.2021-08-20T18-32-01Z
           command:
           - /bin/sh
           - -c

--- a/infrastructure/minio.yml
+++ b/infrastructure/minio.yml
@@ -33,7 +33,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          - 'mkdir -p /storage/spinnaker && /usr/bin/minio server /storage'
+          - 'mkdir -p /storage/spinnaker && /opt/bin/minio server /storage'
           env:
             # MinIO access key and secret key
             - name: MINIO_ACCESS_KEY

--- a/infrastructure/minio.yml
+++ b/infrastructure/minio.yml
@@ -33,7 +33,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          - 'mkdir -p /storage/spinnaker && /opt/bin/minio server /storage'
+          - 'mkdir -p /storage/spinnaker && /usr/bin/minio server /storage'
           env:
             # MinIO access key and secret key
             - name: MINIO_ACCESS_KEY


### PR DESCRIPTION
This is just a cherry-pick of the commits from the master branch to the minnaker branch. It fixes minio in minnaker, see: https://github.com/armory/minnaker/issues/99

Not sure if this PR actually is the right way to do this, given that a rebase of the branch to the current master would contain these fixes anyway. However, the branch has its own patches applied to an older state, and I am not sure if someone would be up to rebase these patches to the current master... And since I cannot get minnaker quite running without issues yet, I cannot do it myself ;) 

I guess for a quick fix this would suffice. These commits can be easily dropped whenever someone rebases the patches. 

Otherwise, don't merge just take this PR as a reminder that the branch has to be fixed.

