### PR TITLE
chore(lambda): upgrade lambda to latest version

### DIFF
--- a/accounts/aws/patch-aws-lambda-plugin.yml
+++ b/accounts/aws/patch-aws-lambda-plugin.yml
@@ -30,21 +30,17 @@ spec:
           extensibility:
               deck-proxy:
                 enabled: true
-                plugins:
+                plugins: &lambda-plugin
                   Aws.LambdaDeploymentPlugin:
                     enabled: true
-                    version: 1.0.1
-              repositories:
+                    version: 1.0.9
+              repositories: &lambda-repository
                 awsLambdaDeploymentPluginRepo:
                   url: https://raw.githubusercontent.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/master/plugins.json  
       orca:
         spinnaker:
           extensibility:
             plugins:
-              Aws.LambdaDeploymentPlugin:
-                enabled: true
-                version: 1.0.1
+              <<: *lambda-plugin
             repositories:
-              awsLambdaDeploymentPluginRepo:
-                id: awsLambdaDeploymentPluginRepo
-                url: https://raw.githubusercontent.com/spinnaker-plugins/aws-lambda-deployment-plugin-spinnaker/master/plugins.json
+              <<: *lambda-repository


### PR DESCRIPTION
This also introduces a simplification in config that we should consider for other parts of the repo, especially for duplicated blocks of config :D the features we're using specifically are [anchors](https://yaml.org/spec/1.1/#id899912), which are part of the native YAML spec and supported by most compliant YAML processors (kustomize included).

They work on scalars as well as maps, so we could just as easily duplicate the plugin config and only create anchors for the version.

This reduces duplication and chances for human error in indentation and/or copy/paste errors. Holler if we want to talk about this change more :)