### PR TITLE
fix(dinghy): allow for dinghy slack notifiers while github slack notifiers are false

### DIFF
--- a/armory/patch-dinghy.yml
+++ b/armory/patch-dinghy.yml
@@ -45,5 +45,6 @@ spec:
 #          password: encrypted:k8s!n:spin-secrets!k:redis-password
 #       # Disable Github pull request notifications (See https://docs.armory.io/armory-enterprise/armory-admin/dinghy-enable/#github-notifications)
 #        notifiers:
+#          enabled: true  # Needs to stay true for spec.spinnakerConfig.config.armory.dinghy.notifiers
 #          github:
 #            enabled: false       # (Default: true) Whether Github pull request notifications are disabled


### PR DESCRIPTION
It was discovered that Dinghy's Slack notifications do not send if Dinghy's Github notifications are disabled. Slack notifications are not affected if Github notifications are enabled or left unconfigured (default enabled).

The workaround is to explicitly enable notifiers in Dinghy's profile when disabling Dinghy's Github notifications.