### PR TITLE
Update minio.yml

### DIFF
--- a/infrastructure/minio.yml
+++ b/infrastructure/minio.yml
@@ -33,7 +33,7 @@ spec:
           command:
           - /bin/sh
           - -c
-          - 'mkdir -p /storage/spinnaker && /usr/bin/minio server /storage'
+          - 'mkdir -p /storage/spinnaker && minio server /storage'
           env:
             # MinIO access key and secret key
             - name: MINIO_ACCESS_KEY


### PR DESCRIPTION
At latest version of minio, the executable file was under '/opt/bin/minio'. As Dockerfile exported '/opt/bin' to PATH env, we can use 'minio' direct.