### PR TITLE
feat(scaleAgent): add patch for ScaleAgent plugin from repo

### DIFF
--- a/plugins/armory-agent/patch-clouddriver-docker.yaml
+++ b/plugins/armory-agent/patch-clouddriver-docker.yaml
@@ -48,4 +48,3 @@ spec:
                   volumes:
                   - name: armory-agent-plugin-vol
                     emptyDir: {}
-```

--- a/plugins/armory-agent/patch-clouddriver-docker.yaml
+++ b/plugins/armory-agent/patch-clouddriver-docker.yaml
@@ -11,38 +11,23 @@ spec:
   spinnakerConfig:
     profiles:
       clouddriver:
-        kubernetes:
-          enabled: true # This is not needed if Spinnaker already has Kubernetes V2 accounts enabled by other files
-
-        sql:
-          enabled: true # kubesvc depends on Clouddriver using SQL. See patch-sql-clouddriver for full configuration
-        redis:
-          enabled: true # kubesvc depends on Redis for internal pub/sub communication
-
-        kubesvc:
-          cluster: redis
-
         spinnaker:
           extensibility:
             pluginsRootPath: /opt/clouddriver/lib/plugins
             plugins:
               Armory.Kubesvc:
                 enabled: true
-                extensions:
-                  armory.kubesvc:
-                    enabled: true
-
+        # Plugin config
+        kubesvc:
+          cluster: kubernetes
+          cluster-kubernetes:
+            kubeconfigFile: <path-to-file> # (Optional, default: null). If configured, the plugin uses this file to discover Endpoints. If not configured, it uses the service account mounted to the pod.
+            verifySsl: <true|false> # Optional, default: true). Whether to verify the Kubernetes API cert or not.
+            namespace: <string> # (Optional, default: null). If configured, the plugin watches Endpoints in this namespace. If null, it watches endpoints in the namespace indicated in the file "/var/run/secrets/kubernetes.io/serviceaccount/namespace".
+            httpPortName: <string> # (Optional, default: http). Name of the port configured in the Clouddriver Service that forwards traffic to the Clouddriver HTTP port for REST requests.
+            clouddriverServiceNamePrefix: <string> # (Optional, default: spin-clouddriver). Name prefix of the Kubernetes Service pointing to the Clouddriver standard HTTP port.
   kustomize:
     clouddriver:
-      service:
-        patchesStrategicMerge:
-          - |
-            spec:
-              ports:
-                - name: http
-                  port: 7002
-                - name: grpc
-                  port: 9091
       deployment:
         patchesStrategicMerge:
           - |
@@ -50,16 +35,17 @@ spec:
               template:
                 spec:
                   initContainers:
-                  - name: kubesvc-plugin
-                    image: docker.io/armory/kubesvc-plugin:0.11.26  # Replace with a version compatible with your Armory CD version
+                  - name: armory-agent-plugin
+                    image: docker.io/armory/kubesvc-plugin:0.11.26 # must be compatible with your Armory CD version
                     volumeMounts:
                       - mountPath: /opt/plugin/target
-                        name: kubesvc-plugin-vol
+                        name: armory-agent-plugin-vol
                   containers:
                   - name: clouddriver
                     volumeMounts:
                       - mountPath: /opt/clouddriver/lib/plugins
-                        name: kubesvc-plugin-vol
+                        name: armory-agent-plugin-vol
                   volumes:
-                  - name: kubesvc-plugin-vol
+                  - name: armory-agent-plugin-vol
                     emptyDir: {}
+```

--- a/plugins/armory-agent/patch-clouddriver-docker.yaml
+++ b/plugins/armory-agent/patch-clouddriver-docker.yaml
@@ -1,8 +1,8 @@
+--- #-----------------------------------------------------------------------------------------------------------------
 #-----------------------------------------------------------------------------------------------------------------
-# Example configuration for adding the Kubernetes Agent plugin to clouddriver
+# Example configuration for adding the Scale Agent plugin Docker image to Clouddriver
 #
-# Documentation: https://docs.armory.io/docs/armory-agent/armory-agent-quick/
-#-----------------------------------------------------------------------------------------------------------------
+# Documentation: https://docs.armory.io/scale-agent/
 apiVersion: spinnaker.armory.io/v1alpha2
 kind: SpinnakerService
 metadata:
@@ -12,12 +12,12 @@ spec:
     profiles:
       clouddriver:
         kubernetes:
-          enabled: true    # This is not needed if spinnaker already has kubernetes V2 accounts enabled by other files
+          enabled: true # This is not needed if Spinnaker already has Kubernetes V2 accounts enabled by other files
 
         sql:
-          enabled: true    # kubesvc depends on clouddriver using SQL. See patch-sql-clouddriver for full configuration
+          enabled: true # kubesvc depends on Clouddriver using SQL. See patch-sql-clouddriver for full configuration
         redis:
-          enabled: true    # kubesvc depends on redis for internal pub/sub communication
+          enabled: true # kubesvc depends on Redis for internal pub/sub communication
 
         kubesvc:
           cluster: redis
@@ -51,7 +51,7 @@ spec:
                 spec:
                   initContainers:
                   - name: kubesvc-plugin
-                    image: docker.io/armory/kubesvc-plugin:0.9.16  # See https://docs.armory.io/docs/armory-agent/armory-agent-quick/ for available versions
+                    image: docker.io/armory/kubesvc-plugin:0.11.26  # Replace with a version compatible with your Armory CD version
                     volumeMounts:
                       - mountPath: /opt/plugin/target
                         name: kubesvc-plugin-vol

--- a/plugins/armory-agent/patch-clouddriver-repo.yaml
+++ b/plugins/armory-agent/patch-clouddriver-repo.yaml
@@ -1,0 +1,35 @@
+#-----------------------------------------------------------------------------------------------------------------
+# Example configuration for adding the Scale Agent plugin to Clouddriver
+#
+# Documentation: https://docs.armory.io/scale-agent/
+#-----------------------------------------------------------------------------------------------------------------
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    profiles:
+      clouddriver:
+        spinnaker:
+          extensibility:
+            repositories:
+              armory-agent-k8s-spinplug-releases:
+                enabled: true
+                url: https://raw.githubusercontent.com/armory-io/agent-k8s-spinplug-releases/master/repositories.json
+            plugins:
+              Armory.Kubesvc:
+                enabled: true
+                version: 0.11.26  # Replace with a version compatible with your Armory CD version
+                extensions:
+                  armory.kubesvc:
+                    enabled: true
+        # Plugin config
+        kubesvc:
+          cluster: kubernetes
+          cluster-kubernetes:
+            kubeconfigFile: <path-to-file> # (Optional, default: null). If configured, the plugin uses this file to discover Endpoints. If not configured, it uses the service account mounted to the pod.
+            verifySsl: <true|false> # Optional, default: true). Whether to verify the Kubernetes API cert or not.
+            namespace: <string> # (Optional, default: null). If configured, the plugin watches Endpoints in this namespace. If null, it watches endpoints in the namespace indicated in the file "/var/run/secrets/kubernetes.io/serviceaccount/namespace".
+            httpPortName: <string> # (Optional, default: http). Name of the port configured in the Clouddriver Service that forwards traffic to the Clouddriver HTTP port for REST requests.
+            clouddriverServiceNamePrefix: <string> # (Optional, default: spin-clouddriver). Name prefix of the Kubernetes Service pointing to the Clouddriver standard HTTP port.

--- a/recipes/kustomization-all.yml
+++ b/recipes/kustomization-all.yml
@@ -23,7 +23,7 @@ components:
 
 #bases:
 #  - infrastructure/prometheus-grafana  # (Optional). Used in conjunction with monitoring/patch-prometheus.yml for monitoring spinnaker
-#  - plugins/armory-agent                    # (Optional). Alternate implementation for kubernetes deployments. Requires plugins/armory-agent/patch-clouddriver.yaml and persistence/patch-sql-clouddriver.yml
+#  - plugins/armory-agent                    # (Optional). Alternate implementation for kubernetes deployments. Requires either plugins/armory-agent/patch-clouddriver-docker.yaml or plugins/armory-agent/patch-clouddriver-repo.yaml, and persistence/patch-sql-clouddriver.yml
 
 patchesStrategicMerge:
 #  - persistence/patch-s3.yml
@@ -96,7 +96,7 @@ patchesStrategicMerge:
 
   # Plugins
 #  - plugins/patch-plugin-wait.yml
-#  - plugins/armory-agent/patch-clouddriver.yaml  # Requires persistence/patch-sql-clouddriver.yml and the base dir plugins/armory-agent
+#  - plugins/armory-agent/patch-clouddriver-docker.yaml or plugins/armory-agent/patch-clouddriver-repo.yaml  # Requires persistence/patch-sql-clouddriver.yml and the base dir plugins/armory-agent
 
 # Mounting any custom files into spinnaker pods (see patch-volumes.yml)
 #generatorOptions:


### PR DESCRIPTION
- Add a new patch file to install the Scale Agent plugin from a plugin repository.
- Rename existing plugin patch file; append "-docker" because that file pulls a Docker image for installation as an initContainer.
- Update comments

I plan to display the contents of these files in the Scale Agent plugin installation content.

Partial Jira: [RBK-637] [RBK-626] [RBK-617]

[RBK-637]: https://armory.atlassian.net/browse/RBK-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RBK-626]: https://armory.atlassian.net/browse/RBK-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RBK-617]: https://armory.atlassian.net/browse/RBK-617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ