### PR TITLE
feat(k8s): add service account secret for k8s 1.24+

### DIFF
--- a/targets/kubernetes/default/service-account.yml
+++ b/targets/kubernetes/default/service-account.yml
@@ -123,6 +123,16 @@ kind: ServiceAccount
 metadata:
   name: spin-sa
 ---
+# This document is required in Kubernetes v1.24+ as secrets are not generated
+# automatically for service accounts.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: spin-sa-token
+  annotations:
+    kubernetes.io/service-account.name: spin-sa
+type: kubernetes.io/service-account-token
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
Newer versions of Kubernetes don't create service account secrets by default. For the purposes of evaluation we now add the secret to the Service Account documents. This works in <1.24, so making it the default going forward.