### PR TITLE
refact(k8s): switch to secret generator to support unique tokens

### DIFF
--- a/targets/kubernetes/default/kustomization.yml
+++ b/targets/kubernetes/default/kustomization.yml
@@ -12,3 +12,12 @@ transformers:
 
 configurations:
   - service-account-bindings.yml
+
+# This document is required in Kubernetes v1.24+ as secrets are not generated
+# automatically for service accounts.
+secretGenerator:
+  - name: spin-sa-token
+    type: "kubernetes.io/service-account-token"
+    options:
+      annotations:
+        kubernetes.io/service-account.name: spin-sa

--- a/targets/kubernetes/default/service-account-bindings.yml
+++ b/targets/kubernetes/default/service-account-bindings.yml
@@ -8,6 +8,8 @@ nameReference:
         path: subjects/name
       - kind: SpinnakerService
         path: spec/spinnakerConfig/service-settings/clouddriver/kubernetes/serviceAccountName
+      - kind: Secret
+        path: metadata/annotations/kubernetes.io\/service-account.name 
   - kind: ClusterRole
     fieldSpecs:
       - kind: ClusterRoleBinding

--- a/targets/kubernetes/default/service-account.yml
+++ b/targets/kubernetes/default/service-account.yml
@@ -123,16 +123,6 @@ kind: ServiceAccount
 metadata:
   name: spin-sa
 ---
-# This document is required in Kubernetes v1.24+ as secrets are not generated
-# automatically for service accounts.
-apiVersion: v1
-kind: Secret
-metadata:
-  name: spin-sa-token
-  annotations:
-    kubernetes.io/service-account.name: spin-sa
-type: kubernetes.io/service-account-token
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
Otherwise tokens would be shared when combined with the unique-service-account transformer, which is extremely undesirable.