### PR TITLE
feat(probes): working config for eks 1.22

### DIFF
--- a/core/probes/kustomization.yml
+++ b/core/probes/kustomization.yml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patchesStrategicMerge:
+  - probes.yml

--- a/core/probes/probes.yml
+++ b/core/probes/probes.yml
@@ -1,0 +1,339 @@
+apiVersion: spinnaker.armory.io/v1alpha2
+kind: SpinnakerService
+metadata:
+  name: spinnaker
+spec:
+  spinnakerConfig:
+    service-settings:
+      clouddriver:
+        kubernetes:
+          livenessProbe:
+            httpGet:
+              port: 7002
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              port: 7002
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              port: 7002
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+      dinghy:
+        kubernetes:
+          livenessProbe:
+            httpGet:
+              port: 8081
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              port: 8081
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              port: 8081
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+      echo:
+        kubernetes:
+          livenessProbe:
+            httpGet:
+              port: 8089
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              port: 8089
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              port: 8089
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+      fiat:
+        kubernetes:
+          livenessProbe:
+            httpGet:
+              port: 7003
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              port: 7003
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              port: 7003
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+      front50:
+        kubernetes:
+          livenessProbe:
+            httpGet:
+              port: 8080
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              port: 8080
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              port: 8080
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+      gate:
+        kubernetes:
+          livenessProbe:
+            httpGet:
+              port: 8084
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              port: 8084
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              port: 8084
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+      igor:
+        kubernetes:
+          livenessProbe:
+            httpGet:
+              port: 8088
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              port: 8088
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              port: 8088
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+      kayenta:
+        kubernetes:
+          livenessProbe:
+            httpGet:
+              port: 8090
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              port: 8090
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              port: 8090
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+      orca:
+        kubernetes:
+          livenessProbe:
+            httpGet:
+              port: 8083
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              port: 8083
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              port: 8083
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+      rosco:
+        kubernetes:
+          livenessProbe:
+            httpGet:
+              port: 8087
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              port: 8087
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              port: 8087
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+      terraformer:
+        kubernetes:
+          livenessProbe:
+            httpGet:
+              port: 7088
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              port: 7088
+              path: /health
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              port: 7088
+              path: /health
+              scheme: HTTP
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3


### PR DESCRIPTION
Several pods (typically echo and gate) have difficulty coming up in eks 1.22 due to failing readiness probes.  In such cases, this config can be applied and should resolve the issue.